### PR TITLE
Fix issue in chrome where select changes size

### DIFF
--- a/scoreboard/scoreboard.css
+++ b/scoreboard/scoreboard.css
@@ -158,6 +158,7 @@ section.political select {
     color: #000;
     padding: 10px;
     cursor: pointer;
+    background: #c7bdd5;
 }
 
 section.political select:hover {


### PR DESCRIPTION
In chrome on OS X, the `<select>` changes size on hover (switches between system and webkit rendering). This fixes the issue. 
![size-issue](https://cloud.githubusercontent.com/assets/5727389/5747896/a9d61318-9c09-11e4-83da-d89d7c705e1e.gif)
