### PR TITLE
add townhall map embedded widget

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -1017,7 +1017,7 @@ body #battle .thanks p a {
 .footer-target footer .socials {
   padding: 10px 0px 20px 0px;
 }
-.footer-target footer .socials img {
+.shares-container img {
   margin: 0px 7px;
   width: 24px;
   height: 24px;
@@ -1042,24 +1042,24 @@ body #battle .thanks p a {
    }
 }
 
-.footer-target .share-container a:hover{
+.shares-container .share-container a:hover{
     color: blue !important;
 }
-.footer-target .share-container a:visited{
+.shares-container .share-container a:visited{
     color: #FFF !important;
 }
-.footer-target .share-container a:link {
+.shares-container .share-container a:link {
     color: #FFF !important;
 }
-.footer-target .fb-share-container{
+.shares-container .fb-share-container{
     background-color: #3B5999;
     padding-left:20px;
 }
-.footer-target .twitter-share-container{
+.shares-container .twitter-share-container{
     background-color: #4099FF;
     padding-left:15px;
 }
-.footer-target .share-container{
+.shares-container .share-container{
     position:relative;
     display:inline-block;
     width: 220px;

--- a/index.html
+++ b/index.html
@@ -329,7 +329,10 @@ header nav a {
       #search_location_list,
       #event_desc,
       #action_info,
-      #can_main_col .last_line {
+      #can_main_col .last_line,
+      #can_embed_form .can_thank_you-block,
+      #can_embed_form .discussion-board,
+      #can_embed_form .thank-you-message .event_map_wrap {
         display: none;
       }
 
@@ -365,6 +368,12 @@ header nav a {
       #can_embed_form input[type='submit']#form-zip_code-submit.text-visible {
         color: white;
         text-shadow: 0 1px 0 rgba(0,0,0,.5);
+      }
+
+      #can_embed_form #can_thank_you {
+        background-color: transparent;
+        border: none;
+        box-shadow: none;
       }
     </style>
 

--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@ header nav a {
         <canvas class="fireworks desktop"></canvas>
     </p>
 
-    <h2 class="tk-proxima-nova">Cable & wireless companies still want the power to censor, block, or slow websites to a crawl. To stop them, we need to get Congress on our side first. Step one? Show up in force at "townhall meeting" near you.</h2>
+    <h2 class="tk-proxima-nova">Cable & wireless companies still want the power to censor, block, or slow websites to a crawl. To stop them, we need to get Congress on our side first. Step one? Show up in force at "town hall meeting" near you.</h2>
 
     <!-- Action Network Townhall Event Campaign Widget -->
     <link href='https://actionnetwork.org/css/style-embed-whitelabel.css' rel='stylesheet' type='text/css' /><script src='https://actionnetwork.org/widgets/v2/event_campaign/stand-up-for-net-neutrality-at-town-hall-events?format=js&source=widget&style=full'></script><div id='can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events' style='width: 600px'><!-- this div is the target for our HTML insertion --></div>
@@ -340,7 +340,6 @@ header nav a {
       #can_embed_form input[type='submit'] {
         background-color: #17A1CE;
         font-family: @body-font, Helvetica, Verdana, sans-serif;
-        text-shadow: 0px 1px 2px rgba(0, 0, 0, .3);
         /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#1bbaee+0,17a1ce+100 */
         background: #1bbaee; /* Old browsers */
         background: -moz-linear-gradient(top, #1bbaee 0%, #17a1ce 100%); /* FF3.6+ */
@@ -357,7 +356,25 @@ header nav a {
         box-shadow: 0px 1px 5px rgba(0, 0, 0, .5);
         text-shadow: 0px;
       }
+
+      #can_embed_form input[type='submit']#form-zip_code-submit {
+        color: transparent;
+        text-shadow: unset;
+      }
+
+      #can_embed_form input[type='submit']#form-zip_code-submit.text-visible {
+        color: white;
+        text-shadow: 0 1px 0 rgba(0,0,0,.5);
+      }
     </style>
+
+    <script type="text/javascript">
+       document.addEventListener('can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events_loaded', function(e) {
+         var zipSubmit = document.getElementById('form-zip_code-submit');
+         zipSubmit.value = 'Find a Town Hall';
+         zipSubmit.classList.add('text-visible');
+       });
+    </script>
 
     <div class="form-wrapper loading tk-proxima-nova" style="display: none;"></div>
 

--- a/index.html
+++ b/index.html
@@ -314,56 +314,50 @@ header nav a {
 
     <h2 class="tk-proxima-nova">Cable & wireless companies still want the power to censor, block, or slow websites to a crawl. To stop them, we need to get Congress on our side first. Step one? Show up in force at "townhall meeting" near you.</h2>
 
+    <!-- Action Network Townhall Event Campaign Widget -->
+    <link href='https://actionnetwork.org/css/style-embed-whitelabel.css' rel='stylesheet' type='text/css' /><script src='https://actionnetwork.org/widgets/v2/event_campaign/stand-up-for-net-neutrality-at-town-hall-events?format=js&source=widget&style=full'></script><div id='can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events' style='width: 600px'><!-- this div is the target for our HTML insertion --></div>
+    
+    <!-- Custom styling for Action Network Widget -->
     <style type="text/css">
-        a.tweet_big_button {
-            display: block;
-            margin: 40px auto 40px auto;
-            background-color: #17A1CE;
-            font-size: 16px;
-            font-weight: bold;
-            text-decoration: none;
-            text-align: center;
-            font-family: @body-font, Helvetica, Verdana, sans-serif;
-            color: white;
-            width: 250px;
-            height: 50px;
-            border-radius: 10px;
-            text-transform: uppercase;
-            line-height: 50px;
-            text-shadow: 0px 1px 2px rgba(0, 0, 0, .3);
-            /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#1bbaee+0,17a1ce+100 */
-            background: #1bbaee; /* Old browsers */
-            background: -moz-linear-gradient(top, #1bbaee 0%, #17a1ce 100%); /* FF3.6+ */
-            background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#1bbaee), color-stop(100%,#17a1ce)); /* Chrome,Safari4+ */
-            background: -webkit-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* Chrome10+,Safari5.1+ */
-            background: -o-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* Opera 11.10+ */
-            background: -ms-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* IE10+ */
-            background: linear-gradient(to bottom, #1bbaee 0%,#17a1ce 100%); /* W3C */
-            filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1bbaee', endColorstr='#17a1ce',GradientType=0 ); /* IE6-9 */
-        }
-        @media screen and (min-width: 400px) {
-            a.tweet_big_button {
-                width: 390px;
-                height: 75px;
-                line-height: 75px;
-                font-size: 23px;
-            }
-        }
-        a.tweet_big_button:hover {
-            background: #17A1CE;
-            box-shadow: 0px 1px 5px rgba(0, 0, 0, .5);
-            text-shadow: 0px;
-        }
-    </style>
-    <a class="tweet_big_button" href="https://actionnetwork.org/event_campaigns/stand-up-for-net-neutrality-at-town-hall-events">Find a Meeting Near You!</a>
+      #can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events {
+        margin: 40px auto 0;
+      }
+      
+      #can_embed_form h2,
+      #can_embed_form h4,
+      #custom_html.mt20,
+      #search_location_list,
+      #event_desc,
+      #action_info,
+      #can_main_col .last_line {
+        display: none;
+      }
 
-    <script type="text/javascript">
-      /*
-      document.querySelector('a.tweet_big_button').addEventListener('click', function(e){
-        e.preventDefault();
-      });
-      */
-    </script>
+      #can_sidebar.mb40 {
+        margin-bottom: 20px;
+      }
+
+      #can_embed_form input[type='submit'] {
+        background-color: #17A1CE;
+        font-family: @body-font, Helvetica, Verdana, sans-serif;
+        text-shadow: 0px 1px 2px rgba(0, 0, 0, .3);
+        /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#1bbaee+0,17a1ce+100 */
+        background: #1bbaee; /* Old browsers */
+        background: -moz-linear-gradient(top, #1bbaee 0%, #17a1ce 100%); /* FF3.6+ */
+        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#1bbaee), color-stop(100%,#17a1ce)); /* Chrome,Safari4+ */
+        background: -webkit-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* Chrome10+,Safari5.1+ */
+        background: -o-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* Opera 11.10+ */
+        background: -ms-linear-gradient(top, #1bbaee 0%,#17a1ce 100%); /* IE10+ */
+        background: linear-gradient(to bottom, #1bbaee 0%,#17a1ce 100%); /* W3C */
+        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1bbaee', endColorstr='#17a1ce',GradientType=0 ); /* IE6-9 */
+      }
+
+      #can_embed_form input[type='submit']:hover {
+        background-color: #17A1CE;
+        box-shadow: 0px 1px 5px rgba(0, 0, 0, .5);
+        text-shadow: 0px;
+      }
+    </style>
 
     <div class="form-wrapper loading tk-proxima-nova" style="display: none;"></div>
 

--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@ header nav a {
         <canvas class="fireworks desktop"></canvas>
     </p>
 
-    <h2 class="tk-proxima-nova">Cable & wireless companies still want the power to censor, block, or slow websites to a crawl. To stop them, we need to get Congress on our side first. Step one? Show up in force at "town hall meeting" near you.</h2>
+    <h2 class="tk-proxima-nova">Cable & wireless companies still want the power to censor, block, or slow websites to a crawl. To stop them, we need to get Congress on our side first. Step one? Show up in force at "town hall meetings" near you.</h2>
 
     <!-- Action Network Townhall Event Campaign Widget -->
     <link href='https://actionnetwork.org/css/style-embed-whitelabel.css' rel='stylesheet' type='text/css' /><script src='https://actionnetwork.org/widgets/v2/event_campaign/stand-up-for-net-neutrality-at-town-hall-events?format=js&source=widget&style=full'></script><div id='can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events' style='width: 600px'><!-- this div is the target for our HTML insertion --></div>
@@ -375,13 +375,29 @@ header nav a {
         border: none;
         box-shadow: none;
       }
+
+      .can_embed .shares-container img {
+        width: 24px;
+      }
     </style>
 
     <script type="text/javascript">
-       document.addEventListener('can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events_loaded', function(e) {
+       document.addEventListener('can_embed_loaded', function(e) {
          var zipSubmit = document.getElementById('form-zip_code-submit');
-         zipSubmit.value = 'Find a Town Hall';
-         zipSubmit.classList.add('text-visible');
+
+         if (zipSubmit) {
+           zipSubmit.value = 'Find a Town Hall';
+           zipSubmit.classList.add('text-visible');
+         }
+       });
+
+       document.addEventListener('can_embed_submitted', function(e) {
+         var thanksEl = document.getElementById('can_thank_you');
+
+         if (thanksEl) {
+           var share = document.querySelector('.shares-container').cloneNode(true);
+           thanksEl.appendChild(share);
+         }
        });
     </script>
 


### PR DESCRIPTION
Replaces link button with Action Network embedded widget, did some minor CSS work to clean up the design a bit, let me know if this works? Downside of the embedded widget appears to be no scrollable list of events, just a map.

<img width="1440" alt="screen shot 2017-04-13 at 1 37 29 pm" src="https://cloud.githubusercontent.com/assets/1149913/25016713/1822381c-204f-11e7-9cce-fee394a8ff39.png">
<img width="1440" alt="screen shot 2017-04-13 at 1 37 51 pm" src="https://cloud.githubusercontent.com/assets/1149913/25016712/181ea198-204f-11e7-849f-35658465aae7.png">


/cc @holmesworcester @evangreer 