### PR TITLE
Fix mobile width of map by defining a max-width instead of width

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -1883,5 +1883,5 @@ fieldset[disabled] textarea {
 }
 
 #can-event_campaign-area-stand-up-for-net-neutrality-at-town-hall-events {
-  width: 600px;
+  max-width: 600px;
 }


### PR DESCRIPTION
Summary:
----

The map seems to bleed into the edge of the screen on mobile viewports. This is due to the `width` being set to 600px. Here's what it looks like in mobile:
<img width="457" alt="screen shot 2017-04-27 at 11 48 17 pm" src="https://cloud.githubusercontent.com/assets/7256178/25517530/bac81270-2ba4-11e7-8f5f-b1b87a908e97.png">

Changes:
----

- [x] Change `width` to `max-width` to allow the map to shrink and it will prevent the map from bleeding over the edge, while also growing up to 600px on desktop viewports.

<img width="389" alt="screen shot 2017-04-27 at 11 50 00 pm" src="https://cloud.githubusercontent.com/assets/7256178/25517533/be163ee8-2ba4-11e7-8b52-56c646a8eb72.png">
